### PR TITLE
Added optional commas

### DIFF
--- a/config/types.db.custom
+++ b/config/types.db.custom
@@ -16,7 +16,7 @@ rabbitmq_messages value:GAUGE:0:U
 rabbitmq_messages_ready value:GAUGE:0:U
 rabbitmq_messages_unacknowledged value:GAUGE:0:U
 rabbitmq_consumers value:GAUGE:0:U
-rabbitmq_details avg:GAUGE:0:U avg_rate:GAUGE:0:U rate:GAUGE:0:U samples:GAUGE:0:U
+rabbitmq_details avg:GAUGE:0:U, avg_rate:GAUGE:0:U, rate:GAUGE:0:U, samples:GAUGE:0:U
 
 ack           value:GAUGE:0:U
 publish       value:GAUGE:0:U


### PR DESCRIPTION
Add optional commas as delimiters. This makes the file compatible with Bucky https://pypi.python.org/pypi/bucky/2.3.0.

I'll log an issue with bucky, but as the commas are described in the collectd docs, they shouldn't break anything.